### PR TITLE
Export classification type definitions for each highlight region type

### DIFF
--- a/DanTup.DartVS.Vsix/DanTup.DartVS.Vsix.csproj
+++ b/DanTup.DartVS.Vsix/DanTup.DartVS.Vsix.csproj
@@ -348,6 +348,7 @@
     <Compile Include="Providers\SmartIndentProvider.cs" />
     <Compile Include="Taggers\AnalysisNotificationTagger.cs" />
     <Compile Include="Taggers\ClassificationTagger.cs" />
+    <Compile Include="Taggers\DartClassificationTypes.cs" />
     <Compile Include="Taggers\ErrorSquiggleTagger.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/DanTup.DartVS.Vsix/Taggers/ClassificationTagger.cs
+++ b/DanTup.DartVS.Vsix/Taggers/ClassificationTagger.cs
@@ -1,12 +1,10 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Linq;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
 using DanTup.DartAnalysis;
 using DanTup.DartAnalysis.Json;
-using Microsoft.VisualStudio.Language.StandardClassification;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Classification;
 using Microsoft.VisualStudio.Text.Tagging;
@@ -36,59 +34,22 @@ namespace DanTup.DartVS
 
 	class ClassificationTagger : AnalysisNotificationTagger<ClassificationTag, HighlightRegion, AnalysisHighlightsNotification>
 	{
-		IDictionary<HighlightRegionType, IClassificationType> classificationMapping;
+		IClassificationType[] classificationMapping;
 
 		public ClassificationTagger(ITextBuffer buffer, ITextDocumentFactoryService textDocumentFactory, DartAnalysisServiceFactory analysisServiceFactory, IClassificationTypeRegistryService typeService)
 			: base(buffer, textDocumentFactory, analysisServiceFactory)
 		{
-			// Mapping of Analysis Server's HighlightRegionTypes to the VS Classifications we wish to give them.
-			classificationMapping = new Dictionary<HighlightRegionType, IClassificationType>
-			{
-				// TODO: Replace any 'Other' with something more appropriate (eg. NaturalLanguage/FormatLanguage or more specific).
-				// NOTE: We must map *everything* here, because Tooltips rely on these tags to calculate applicableTo spans immediately.
-				{ HighlightRegionType.Annotation, typeService.GetClassificationType(PredefinedClassificationTypeNames.SymbolReference) },
-				{ HighlightRegionType.BuiltIn, typeService.GetClassificationType(PredefinedClassificationTypeNames.Keyword) },
-				{ HighlightRegionType.Class, typeService.GetClassificationType(PredefinedClassificationTypeNames.SymbolReference) },
-				{ HighlightRegionType.CommentBlock, typeService.GetClassificationType(PredefinedClassificationTypeNames.Comment) },
-				{ HighlightRegionType.CommentDocumentation, typeService.GetClassificationType(PredefinedClassificationTypeNames.Comment) },
-				{ HighlightRegionType.CommentEndOfLine, typeService.GetClassificationType(PredefinedClassificationTypeNames.Comment) },
-				{ HighlightRegionType.Constructor, typeService.GetClassificationType(PredefinedClassificationTypeNames.Other) },
-				{ HighlightRegionType.Directive, typeService.GetClassificationType(PredefinedClassificationTypeNames.Other) },
-				{ HighlightRegionType.DynamicType, typeService.GetClassificationType(PredefinedClassificationTypeNames.Other) },
-				{ HighlightRegionType.Field, typeService.GetClassificationType(PredefinedClassificationTypeNames.Other) },
-				{ HighlightRegionType.FieldStatic, typeService.GetClassificationType(PredefinedClassificationTypeNames.Other) },
-				{ HighlightRegionType.Function, typeService.GetClassificationType(PredefinedClassificationTypeNames.Other) },
-				{ HighlightRegionType.FunctionDeclaration, typeService.GetClassificationType(PredefinedClassificationTypeNames.Other) },
-				{ HighlightRegionType.FunctionTypeAlias, typeService.GetClassificationType(PredefinedClassificationTypeNames.Other) },
-				{ HighlightRegionType.GetterDeclaration, typeService.GetClassificationType(PredefinedClassificationTypeNames.Other) },
-				{ HighlightRegionType.IdentifierDefault, typeService.GetClassificationType(PredefinedClassificationTypeNames.Other) },
-				{ HighlightRegionType.ImportPrefix, typeService.GetClassificationType(PredefinedClassificationTypeNames.Other) },
-				{ HighlightRegionType.Keyword, typeService.GetClassificationType(PredefinedClassificationTypeNames.Keyword) },
-				{ HighlightRegionType.LiteralBoolean, typeService.GetClassificationType(PredefinedClassificationTypeNames.Keyword) },
-				{ HighlightRegionType.LiteralDouble, typeService.GetClassificationType(PredefinedClassificationTypeNames.Number) },
-				{ HighlightRegionType.LiteralInteger, typeService.GetClassificationType(PredefinedClassificationTypeNames.Number) },
-				{ HighlightRegionType.LiteralList, typeService.GetClassificationType(PredefinedClassificationTypeNames.Other) },
-				{ HighlightRegionType.LiteralMap, typeService.GetClassificationType(PredefinedClassificationTypeNames.Other) },
-				{ HighlightRegionType.LiteralString, typeService.GetClassificationType(PredefinedClassificationTypeNames.Other) },
-				{ HighlightRegionType.LocalVariable, typeService.GetClassificationType(PredefinedClassificationTypeNames.Other) },
-				{ HighlightRegionType.LocalVariableDeclaration, typeService.GetClassificationType(PredefinedClassificationTypeNames.Other) },
-				{ HighlightRegionType.Method, typeService.GetClassificationType(PredefinedClassificationTypeNames.Other) },
-				{ HighlightRegionType.MethodDeclaration, typeService.GetClassificationType(PredefinedClassificationTypeNames.Other) },
-				{ HighlightRegionType.MethodDeclarationStatic, typeService.GetClassificationType(PredefinedClassificationTypeNames.Other) },
-				{ HighlightRegionType.MethodStatic, typeService.GetClassificationType(PredefinedClassificationTypeNames.Other) },
-				{ HighlightRegionType.Parameter, typeService.GetClassificationType(PredefinedClassificationTypeNames.Other) },
-				{ HighlightRegionType.SetterDeclaration, typeService.GetClassificationType(PredefinedClassificationTypeNames.Other) },
-				{ HighlightRegionType.TopLevelVariable, typeService.GetClassificationType(PredefinedClassificationTypeNames.Other) },
-				{ HighlightRegionType.TypeNameDynamic, typeService.GetClassificationType(PredefinedClassificationTypeNames.Other) },
-				{ HighlightRegionType.TypeParameter, typeService.GetClassificationType(PredefinedClassificationTypeNames.Other) },
-			};
+			Array values = Enum.GetValues(typeof(HighlightRegionType));
+			classificationMapping = new IClassificationType[values.Length];
+			for (int i = 0; i < classificationMapping.Length; i++)
+				classificationMapping[i] = typeService.GetClassificationType(DartConstants.ContentType + ((HighlightRegionType)i).ToString());
 
 			this.Subscribe();
 		}
 
 		protected override ITagSpan<ClassificationTag> CreateTag(HighlightRegion highlight)
 		{
-			return new TagSpan<ClassificationTag>(new SnapshotSpan(buffer.CurrentSnapshot, highlight.Offset, highlight.Length), new ClassificationTag(classificationMapping[highlight.Type]));
+			return new TagSpan<ClassificationTag>(new SnapshotSpan(buffer.CurrentSnapshot, highlight.Offset, highlight.Length), new ClassificationTag(classificationMapping[(int)highlight.Type]));
 		}
 
 		protected override async Task<IDisposable> SubscribeAsync(Action<AnalysisHighlightsNotification> updateSourceData)
@@ -104,7 +65,7 @@ namespace DanTup.DartVS
 			if (classificationMapping == null)
 				return new HighlightRegion[0];
 
-			return notification.Regions.Where(h => classificationMapping.ContainsKey(h.Type)).ToArray();
+			return notification.Regions.Where(h => h.Type >= 0 && (int)h.Type < classificationMapping.Length).ToArray();
 		}
 
 		protected override Tuple<int, int> GetOffsetAndLength(HighlightRegion data)

--- a/DanTup.DartVS.Vsix/Taggers/DartClassificationTypes.cs
+++ b/DanTup.DartVS.Vsix/Taggers/DartClassificationTypes.cs
@@ -1,0 +1,209 @@
+﻿using System.ComponentModel.Composition;
+using DanTup.DartAnalysis.Json;
+using Microsoft.VisualStudio.Language.StandardClassification;
+using Microsoft.VisualStudio.Text.Classification;
+using Microsoft.VisualStudio.Utilities;
+
+namespace DanTup.DartVS.Taggers
+{
+	internal static class DartClassificationTypes
+	{
+		[Export]
+		[ClassificationTypeName(HighlightRegionType.Annotation)]
+		[BaseDefinition(PredefinedClassificationTypeNames.SymbolReference)]
+		private static readonly ClassificationTypeDefinition Annotation;
+
+		[Export]
+		[ClassificationTypeName(HighlightRegionType.BuiltIn)]
+		[BaseDefinition(PredefinedClassificationTypeNames.Keyword)]
+		private static readonly ClassificationTypeDefinition BuiltIn;
+
+		[Export]
+		[ClassificationTypeName(HighlightRegionType.Class)]
+		[BaseDefinition(PredefinedClassificationTypeNames.SymbolReference)]
+		private static readonly ClassificationTypeDefinition Class;
+
+		[Export]
+		[ClassificationTypeName(HighlightRegionType.CommentBlock)]
+		[BaseDefinition(PredefinedClassificationTypeNames.Comment)]
+		private static readonly ClassificationTypeDefinition CommentBlock;
+
+		[Export]
+		[ClassificationTypeName(HighlightRegionType.CommentDocumentation)]
+		[BaseDefinition(PredefinedClassificationTypeNames.Comment)]
+		private static readonly ClassificationTypeDefinition CommentDocumentation;
+
+		[Export]
+		[ClassificationTypeName(HighlightRegionType.CommentEndOfLine)]
+		[BaseDefinition(PredefinedClassificationTypeNames.Comment)]
+		private static readonly ClassificationTypeDefinition CommentEndOfLine;
+
+		[Export]
+		[ClassificationTypeName(HighlightRegionType.Constructor)]
+		[BaseDefinition(PredefinedClassificationTypeNames.Identifier)]
+		private static readonly ClassificationTypeDefinition Constructor;
+
+		[Export]
+		[ClassificationTypeName(HighlightRegionType.Directive)]
+		[BaseDefinition(PredefinedClassificationTypeNames.Identifier)]
+		private static readonly ClassificationTypeDefinition Directive;
+
+		[Export]
+		[ClassificationTypeName(HighlightRegionType.DynamicType)]
+		[BaseDefinition(PredefinedClassificationTypeNames.Identifier)]
+		private static readonly ClassificationTypeDefinition DynamicType;
+
+		[Export]
+		[ClassificationTypeName(HighlightRegionType.Field)]
+		[BaseDefinition(PredefinedClassificationTypeNames.Identifier)]
+		private static readonly ClassificationTypeDefinition Field;
+
+		[Export]
+		[ClassificationTypeName(HighlightRegionType.FieldStatic)]
+		[BaseDefinition(PredefinedClassificationTypeNames.Identifier)]
+		private static readonly ClassificationTypeDefinition FieldStatic;
+
+		[Export]
+		[ClassificationTypeName(HighlightRegionType.Function)]
+		[BaseDefinition(PredefinedClassificationTypeNames.Identifier)]
+		private static readonly ClassificationTypeDefinition Function;
+
+		[Export]
+		[ClassificationTypeName(HighlightRegionType.FunctionDeclaration)]
+		[BaseDefinition(PredefinedClassificationTypeNames.Identifier)]
+		private static readonly ClassificationTypeDefinition FunctionDeclaration;
+
+		[Export]
+		[ClassificationTypeName(HighlightRegionType.FunctionTypeAlias)]
+		[BaseDefinition(PredefinedClassificationTypeNames.Identifier)]
+		private static readonly ClassificationTypeDefinition FunctionTypeAlias;
+
+		[Export]
+		[ClassificationTypeName(HighlightRegionType.GetterDeclaration)]
+		[BaseDefinition(PredefinedClassificationTypeNames.Identifier)]
+		private static readonly ClassificationTypeDefinition GetterDeclaration;
+
+		[Export]
+		[ClassificationTypeName(HighlightRegionType.IdentifierDefault)]
+		[BaseDefinition(PredefinedClassificationTypeNames.Identifier)]
+		private static readonly ClassificationTypeDefinition IdentifierDefault;
+
+		[Export]
+		[ClassificationTypeName(HighlightRegionType.ImportPrefix)]
+		[BaseDefinition(PredefinedClassificationTypeNames.Identifier)]
+		private static readonly ClassificationTypeDefinition ImportPrefix;
+
+		[Export]
+		[ClassificationTypeName(HighlightRegionType.Keyword)]
+		[BaseDefinition(PredefinedClassificationTypeNames.Keyword)]
+		private static readonly ClassificationTypeDefinition Keyword;
+
+		[Export]
+		[ClassificationTypeName(HighlightRegionType.Label)]
+		[BaseDefinition(PredefinedClassificationTypeNames.Identifier)]
+		private static readonly ClassificationTypeDefinition Label;
+
+		[Export]
+		[ClassificationTypeName(HighlightRegionType.LiteralBoolean)]
+		[BaseDefinition(PredefinedClassificationTypeNames.Keyword)]
+		private static readonly ClassificationTypeDefinition LiteralBoolean;
+
+		[Export]
+		[ClassificationTypeName(HighlightRegionType.LiteralDouble)]
+		[BaseDefinition(PredefinedClassificationTypeNames.Number)]
+		private static readonly ClassificationTypeDefinition LiteralDouble;
+
+		[Export]
+		[ClassificationTypeName(HighlightRegionType.LiteralInteger)]
+		[BaseDefinition(PredefinedClassificationTypeNames.Number)]
+		private static readonly ClassificationTypeDefinition LiteralInteger;
+
+		[Export]
+		[ClassificationTypeName(HighlightRegionType.LiteralList)]
+		[BaseDefinition(PredefinedClassificationTypeNames.Other)]
+		private static readonly ClassificationTypeDefinition LiteralList;
+
+		[Export]
+		[ClassificationTypeName(HighlightRegionType.LiteralMap)]
+		[BaseDefinition(PredefinedClassificationTypeNames.Other)]
+		private static readonly ClassificationTypeDefinition LiteralMap;
+
+		[Export]
+		[ClassificationTypeName(HighlightRegionType.LiteralString)]
+		[BaseDefinition(PredefinedClassificationTypeNames.String)]
+		private static readonly ClassificationTypeDefinition LiteralString;
+
+		[Export]
+		[ClassificationTypeName(HighlightRegionType.LocalVariable)]
+		[BaseDefinition(PredefinedClassificationTypeNames.Identifier)]
+		private static readonly ClassificationTypeDefinition LocalVariable;
+
+		[Export]
+		[ClassificationTypeName(HighlightRegionType.LocalVariableDeclaration)]
+		[BaseDefinition(PredefinedClassificationTypeNames.Identifier)]
+		private static readonly ClassificationTypeDefinition LocalVariableDeclaration;
+
+		[Export]
+		[ClassificationTypeName(HighlightRegionType.Method)]
+		[BaseDefinition(PredefinedClassificationTypeNames.Identifier)]
+		private static readonly ClassificationTypeDefinition Method;
+
+		[Export]
+		[ClassificationTypeName(HighlightRegionType.MethodDeclaration)]
+		[BaseDefinition(PredefinedClassificationTypeNames.Identifier)]
+		private static readonly ClassificationTypeDefinition MethodDeclaration;
+
+		[Export]
+		[ClassificationTypeName(HighlightRegionType.MethodDeclarationStatic)]
+		[BaseDefinition(PredefinedClassificationTypeNames.Identifier)]
+		private static readonly ClassificationTypeDefinition MethodDeclarationStatic;
+
+		[Export]
+		[ClassificationTypeName(HighlightRegionType.MethodStatic)]
+		[BaseDefinition(PredefinedClassificationTypeNames.Identifier)]
+		private static readonly ClassificationTypeDefinition MethodStatic;
+
+		[Export]
+		[ClassificationTypeName(HighlightRegionType.Parameter)]
+		[BaseDefinition(PredefinedClassificationTypeNames.Identifier)]
+		private static readonly ClassificationTypeDefinition Parameter;
+
+		[Export]
+		[ClassificationTypeName(HighlightRegionType.SetterDeclaration)]
+		[BaseDefinition(PredefinedClassificationTypeNames.Identifier)]
+		private static readonly ClassificationTypeDefinition SetterDeclaration;
+
+		[Export]
+		[ClassificationTypeName(HighlightRegionType.TopLevelVariable)]
+		[BaseDefinition(PredefinedClassificationTypeNames.Identifier)]
+		private static readonly ClassificationTypeDefinition TopLevelVariable;
+
+		[Export]
+		[ClassificationTypeName(HighlightRegionType.TypeNameDynamic)]
+		[BaseDefinition(PredefinedClassificationTypeNames.Identifier)]
+		private static readonly ClassificationTypeDefinition TypeNameDynamic;
+
+		[Export]
+		[ClassificationTypeName(HighlightRegionType.TypeParameter)]
+		[BaseDefinition(PredefinedClassificationTypeNames.Identifier)]
+		private static readonly ClassificationTypeDefinition TypeParameter;
+
+		private sealed class ClassificationTypeNameAttribute : SingletonBaseMetadataAttribute
+		{
+			private readonly string _name;
+
+			public ClassificationTypeNameAttribute(HighlightRegionType highlightRegionType)
+			{
+				_name = DartConstants.ContentType + highlightRegionType.ToString();
+			}
+
+			public string Name
+			{
+				get
+				{
+					return _name;
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
- Fixes #63 
- Adds missing definition for `Label`
- Fixes base definition for `LiteralString`
- Changes most instances of `Other` to `Identifier`
