### PR TITLE
Use wildcard includes in the project templates

### DIFF
--- a/Templates/Project/DartConsoleApplicationProjectTemplate/DartConsoleApplicationProject.dartproj
+++ b/Templates/Project/DartConsoleApplicationProjectTemplate/DartConsoleApplicationProject.dartproj
@@ -26,10 +26,8 @@
     <WarningsAsErrors />
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="bin\$safeprojectname$.dart"/>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="pubspec.yaml"/>
+    <Compile Include="**\*.dart"/>
+    <None Include="**\*.*" Exclude="**\*.dart;**\*.dartproj"/>
   </ItemGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Templates/Project/DartPackageProjectTemplate/DartPackageProject.dartproj
+++ b/Templates/Project/DartPackageProjectTemplate/DartPackageProject.dartproj
@@ -26,11 +26,8 @@
     <WarningsAsErrors />
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="lib\$safeprojectname$.dart"/>
-    <Compile Include="test\test.dart"/>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="pubspec.yaml"/>
+    <Compile Include="**\*.dart"/>
+    <None Include="**\*.*" Exclude="**\*.dart;**\*.dartproj"/>
   </ItemGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Templates/Project/DartSampleProjectTemplate/DartSampleProject.dartproj
+++ b/Templates/Project/DartSampleProjectTemplate/DartSampleProject.dartproj
@@ -26,20 +26,8 @@
     <WarningsAsErrors />
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="bin\echo.dart"/>
-    <Compile Include="bin\print_day.dart"/>
-    <Compile Include="lib\hello.dart"/>
-    <Compile Include="test\all.dart"/>
-    <Compile Include="test\run_in_browser.dart"/>
-    <Compile Include="web\main.dart"/>
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="test\index.html"/>
-    <Content Include="web\index.html"/>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="README.md"/>
-    <None Include="pubspec.yaml"/>
+    <Compile Include="**\*.dart"/>
+    <None Include="**\*.*" Exclude="**\*.dart;**\*.dartproj"/>
   </ItemGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Templates/Project/DartWebApplicationProjectTemplate/DartWebApplicationProject.dartproj
+++ b/Templates/Project/DartWebApplicationProjectTemplate/DartWebApplicationProject.dartproj
@@ -26,13 +26,8 @@
     <WarningsAsErrors />
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="web\$safeprojectname$.dart"/>
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="web\$safeprojectname$.html"/>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="pubspec.yaml"/>
+    <Compile Include="**\*.dart"/>
+    <None Include="**\*.*" Exclude="**\*.dart;**\*.dartproj"/>
   </ItemGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
# Work In Progress

Fixes #59 

This pull request may result in unintended behavior of the project system for operations including, but not limited to:
1. Creating new files on the file system, and then attempting to add them to a project that was already open within Visual Studio
2. Renaming files using Solution Explorer
3. Drag & drop within Solution Explorer
4. Cut/Copy & paste within Solution Explorer

If any of these operations produces "bizarre" behavior, this pull request should be updated to disable the associated command at least until the behavior can be properly specified and corrected.
