### PR TITLE
Hide the References node in Solution Explorer

### DIFF
--- a/DanTup.DartVS.Vsix/ProjectSystem/DartProjectNode.cs
+++ b/DanTup.DartVS.Vsix/ProjectSystem/DartProjectNode.cs
@@ -208,7 +208,9 @@
 
         protected override ReferenceContainerNode CreateReferenceContainerNode()
         {
-            return new DartReferenceContainerNode(this);
+            // Hiding the References node for now.
+            // See: https://github.com/DartVS/DartVS/issues/53
+            return null;
         }
 
         public override FileNode CreateFileNode(ProjectElement item)


### PR DESCRIPTION
Fixes #61
