### PR TITLE
Pub integration

### DIFF
--- a/DanTup.DartVS.Vsix/DanTup.DartVS.Vsix.csproj
+++ b/DanTup.DartVS.Vsix/DanTup.DartVS.Vsix.csproj
@@ -428,6 +428,10 @@
       <Project>{d623dced-f976-4caf-96be-24c2a6d8950a}</Project>
       <Name>DartVS.Common</Name>
     </ProjectReference>
+    <ProjectReference Include="..\DartVS.Pub\DartVS.Pub.csproj">
+      <Project>{5192cebe-637b-4da2-aa87-5664be91509c}</Project>
+      <Name>DartVS.Pub</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Templates\Item\DartClassItemTemplate\DartClassItemTemplate.csproj">
       <Project>{4371e445-c653-4470-becf-7f69870725f3}</Project>
       <Name>DartClassItemTemplate</Name>

--- a/DanTup.DartVS.Vsix/ProjectSystem/DartProjectFactory.cs
+++ b/DanTup.DartVS.Vsix/ProjectSystem/DartProjectFactory.cs
@@ -3,6 +3,7 @@
 	using System;
 	using System.Runtime.InteropServices;
 	using Microsoft.VisualStudio.Project;
+	using global::DartVS.Pub;
 
 	using IOleServiceProvider = Microsoft.VisualStudio.OLE.Interop.IServiceProvider;
 
@@ -28,6 +29,20 @@
 			IOleServiceProvider serviceProvider = (IOleServiceProvider)((IServiceProvider)base.Package).GetService(typeof(IOleServiceProvider));
 			node.SetSite(serviceProvider);
 			return node;
+		}
+
+		protected override void CreateProject(string fileName, string location, string name, uint flags, ref Guid projectGuid, out IntPtr project, out int canceled)
+		{
+			base.CreateProject(fileName, location, name, flags, ref projectGuid, out project, out canceled);
+
+			// TODO: Wire this up.
+			Action<string> writeToOutputPane = delegate(string message) { };
+
+			// TOOD: Should this come via MEF? Is it possible here?
+			var pub = new PubService();
+
+			// TODO: Is it safe to block here? 
+			pub.GetAsync(location, writeToOutputPane).Wait();
 		}
 	}
 }

--- a/DanTup.DartVS.sln
+++ b/DanTup.DartVS.sln
@@ -91,6 +91,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DartCodeFileItemTemplate", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DartVS.Common", "DartVS.Common\DartVS.Common.csproj", "{D623DCED-F976-4CAF-96BE-24C2A6D8950A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DartVS.Pub", "DartVS.Pub\DartVS.Pub.csproj", "{5192CEBE-637B-4DA2-AA87-5664BE91509C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -145,6 +147,10 @@ Global
 		{D623DCED-F976-4CAF-96BE-24C2A6D8950A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D623DCED-F976-4CAF-96BE-24C2A6D8950A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D623DCED-F976-4CAF-96BE-24C2A6D8950A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5192CEBE-637B-4DA2-AA87-5664BE91509C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5192CEBE-637B-4DA2-AA87-5664BE91509C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5192CEBE-637B-4DA2-AA87-5664BE91509C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5192CEBE-637B-4DA2-AA87-5664BE91509C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/DartVS.Pub/DartVS.Pub.csproj
+++ b/DartVS.Pub/DartVS.Pub.csproj
@@ -31,6 +31,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -42,7 +43,14 @@
     <Compile Include="..\DanTup.DartVS.Vsix\Properties\SharedAssemblyInfo.cs">
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="PubService.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\DartVS.Common\DartVS.Common.csproj">
+      <Project>{d623dced-f976-4caf-96be-24c2a6d8950a}</Project>
+      <Name>DartVS.Common</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/DartVS.Pub/DartVS.Pub.csproj
+++ b/DartVS.Pub/DartVS.Pub.csproj
@@ -1,0 +1,55 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{5192CEBE-637B-4DA2-AA87-5664BE91509C}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>DartVS.Pub</RootNamespace>
+    <AssemblyName>DartVS.Pub</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\DanTup.DartVS.Vsix\Properties\SharedAssemblyInfo.cs">
+      <Link>Properties\SharedAssemblyInfo.cs</Link>
+    </Compile>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/DartVS.Pub/Properties/AssemblyInfo.cs
+++ b/DartVS.Pub/Properties/AssemblyInfo.cs
@@ -1,0 +1,5 @@
+﻿using System.Reflection;
+
+[assembly: AssemblyTitle("DartVS: Pub Integration")]
+[assembly: AssemblyProduct("DartVS: Pub Integration")]
+

--- a/DartVS.Pub/PubService.cs
+++ b/DartVS.Pub/PubService.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.ComponentModel.Composition;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace DartVS.Pub
+{
+	/// <summary>
+	/// Wrapper around command-line Pub application.
+	/// </summary>
+	[Export]
+	public class PubService
+	{
+		/// <summary>
+		/// Runs "pub get" in the provided directory.
+		/// </summary>
+		/// <param name="projectRoot">Thedirectory to run "pub get" from.</param>
+		/// <param name="outputHandler">A function to receive any output from pub (STDOUT/STDERR).</param>
+		/// <returns>The exit code from pub.</returns>
+		public async Task<bool> GetAsync(string projectRoot, Action<string> outputHandler)
+		{
+			var sdkFolder = await DartSdk.GetSdkPathAsync();
+
+			using (var proc = new StdIOService(projectRoot, Path.Combine(sdkFolder, @"bin\pub.bat"), "get", outputHandler, outputHandler))
+				return proc.WaitForExit() >= 0;
+		}
+	}
+}


### PR DESCRIPTION
This change runs "pub get" when a project is created; which will fetch any packages (similar to NuGet Package Restore).

This will fix any errors/warnings in default templates caused by references to pub packages.

Note: This PR currently includes some changesets from the project-refactor branch because my Git skills are a bit lame!
