### PR TITLE
Remove AnalysisService code from solution.

### DIFF
--- a/DanTup.DartVS.sln
+++ b/DanTup.DartVS.sln
@@ -17,27 +17,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DanTup.DartAnalysis", "DanT
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DanTup.DartAnalysis.Tests", "DanTup.DartAnalysis.Tests\DanTup.DartAnalysis.Tests.csproj", "{464141D0-63EA-4956-9C5C-142EE3906B00}"
 EndProject
-Project("{E24C65DC-7377-472B-9ABA-BC803B73C61A}") = "analysis_server", "http://localhost:57920", "{0C6FC1E7-DD9B-448C-9D5D-1CB31E742492}"
-	ProjectSection(WebsiteProperties) = preProject
-		UseIISExpress = "true"
-		TargetFrameworkMoniker = ".NETFramework,Version%3Dv4.0"
-		Debug.AspNetCompiler.VirtualPath = "/localhost_57920"
-		Debug.AspNetCompiler.PhysicalPath = "..\Dart\dart\pkg\analysis_server\"
-		Debug.AspNetCompiler.TargetPath = "PrecompiledWeb\localhost_57920\"
-		Debug.AspNetCompiler.Updateable = "true"
-		Debug.AspNetCompiler.ForceOverwrite = "true"
-		Debug.AspNetCompiler.FixedNames = "false"
-		Debug.AspNetCompiler.Debug = "True"
-		Release.AspNetCompiler.VirtualPath = "/localhost_57920"
-		Release.AspNetCompiler.PhysicalPath = "..\Dart\dart\pkg\analysis_server\"
-		Release.AspNetCompiler.TargetPath = "PrecompiledWeb\localhost_57920\"
-		Release.AspNetCompiler.Updateable = "true"
-		Release.AspNetCompiler.ForceOverwrite = "true"
-		Release.AspNetCompiler.FixedNames = "false"
-		Release.AspNetCompiler.Debug = "False"
-		SlnRelativePath = "..\Dart\dart\pkg\analysis_server\"
-	EndProjectSection
-EndProject
 Project("{E24C65DC-7377-472B-9ABA-BC803B73C61A}") = "DanTup.DartAnalysis.Tests.SampleDartProject", "http://localhost:49251", "{88C4EE36-6BF1-4144-8081-126217A59B56}"
 	ProjectSection(WebsiteProperties) = preProject
 		UseIISExpress = "true"
@@ -109,10 +88,6 @@ Global
 		{464141D0-63EA-4956-9C5C-142EE3906B00}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{464141D0-63EA-4956-9C5C-142EE3906B00}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{464141D0-63EA-4956-9C5C-142EE3906B00}.Release|Any CPU.Build.0 = Release|Any CPU
-		{0C6FC1E7-DD9B-448C-9D5D-1CB31E742492}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{0C6FC1E7-DD9B-448C-9D5D-1CB31E742492}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{0C6FC1E7-DD9B-448C-9D5D-1CB31E742492}.Release|Any CPU.ActiveCfg = Debug|Any CPU
-		{0C6FC1E7-DD9B-448C-9D5D-1CB31E742492}.Release|Any CPU.Build.0 = Debug|Any CPU
 		{88C4EE36-6BF1-4144-8081-126217A59B56}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{88C4EE36-6BF1-4144-8081-126217A59B56}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{88C4EE36-6BF1-4144-8081-126217A59B56}.Release|Any CPU.ActiveCfg = Debug|Any CPU


### PR DESCRIPTION
This was as a convenience while wiring up the analysis service; doesn't
serve much purpose now (and won't work for those without the Dart repo
checked out).
